### PR TITLE
Adds a circular deque (to make controlgris2 real-time safer)

### DIFF
--- a/Containers/circular_deque.hpp
+++ b/Containers/circular_deque.hpp
@@ -14,72 +14,72 @@ concept arithmetic = std::is_arithmetic_v<T>;
  * Written as a fixed sized non allocating replacement for std::deque usage in controlgris.
  */
 template <arithmetic T, std::size_t S>
-class circular_deque {
+class CircularDeque {
  private:
-  int head_index;
+  int headIndex;
 
   /**
    * Array of the elements
    */
   std::array<T, S> content;
-  std::size_t max_size;
-  int current_size;
+  std::size_t maxSize;
+  int currentSize;
 
  public:
 
-  circular_deque()
-      : max_size(S),
+  CircularDeque()
+      : maxSize(S),
         content{},
-        head_index{0},
-        current_size{0}
+        headIndex{0},
+        currentSize{0}
   {}
 
-  std::size_t get_max_size() {
-    return max_size;
+  std::size_t getMaxSize() {
+    return maxSize;
   }
 
-  std::size_t get_current_size() {
-    return max_size;
+  std::size_t getCurrentSize() {
+    return maxSize;
   }
 
   /**
    * Pop from the circular buffer.
-   * You will get "garbage" if you try to pop while current_size == 0
+   * You will get "garbage" if you try to pop while currentSize == 0
    */
   T pop() {
-    head_index = (head_index - 1) <= 0 ? max_size - 1 : head_index - 1;
-    current_size = current_size - 1 <= 0 ? 0 : current_size - 1;
-    return content[head_index];
+    headIndex = (headIndex - 1) <= 0 ? maxSize - 1 : headIndex - 1;
+    currentSize = currentSize - 1 <= 0 ? 0 : currentSize - 1;
+    return content[headIndex];
   }
 
   /**
-   * push a new element. You will overwrite the first element if current_size == max_size
+   * push a new element. You will overwrite the first element if currentSize == maxSize
    */
   void push(T elem) {
-    content[head_index] = elem;
-    head_index += 1;
-    head_index %= max_size;
-    current_size = (current_size + 1) >= max_size ? max_size : current_size + 1;
+    content[headIndex] = elem;
+    headIndex += 1;
+    headIndex %= maxSize;
+    currentSize = (currentSize + 1) >= maxSize ? maxSize : currentSize + 1;
   }
 
   /**
    * Returns the numerically maximal element.
-   * If you call this with current_size == 0 you will get garbage.
+   * If you call this with currentSize == 0 you will get garbage.
    */
   T max() {
-    std::size_t read_idx = head_index - 1 <= 0 ? max_size - 1 : head_index - 1;
+    std::size_t read_idx = headIndex - 1 <= 0 ? maxSize - 1 : headIndex - 1;
     T max_value{content[read_idx]};
-    for (int i = 1; i < current_size; i++) {
-      max_value = std::max(content[(read_idx + i) % max_size], max_value);
+    for (int i = 1; i < currentSize; i++) {
+      max_value = std::max(content[(read_idx + i) % maxSize], max_value);
     }
     return max_value;
   }
 
   /**
-   * Just marks current_size to 0, doesn't actually clear any values.
+   * Just marks currentSize to 0, doesn't actually clear any values.
    */
   void clear() {
-    current_size = 0;
+    currentSize = 0;
   }
 };
 }  // end namespace mmesh


### PR DESCRIPTION
This adds a minimalist "circular deque" structure that implements the minimum features needed to replace std::deque in controlGRIS2.