### PR TITLE
Enable switching to parallel algorithm at runtime using the std::atomic_ref implementation of fork_union.

### DIFF
--- a/Containers/sg_TaggedAudioBuffer.hpp
+++ b/Containers/sg_TaggedAudioBuffer.hpp
@@ -119,7 +119,7 @@ public:
     //==============================================================================
     void copyToPhysicalOutput(float * const * outs, int const numOutputs) const
     {
-        // TODO FU: this could probably be parallelized with fork_union
+        // TODO : this could probably be parallelized with fork_union
         for (auto const buffer : mBuffers) {
             auto const outIndex{ buffer.key.template removeOffset<int>() };
             jassert(outIndex >= 0);

--- a/Data/sg_LogicStrucs.cpp
+++ b/Data/sg_LogicStrucs.cpp
@@ -93,7 +93,9 @@ juce::String const ProjectData::XmlTags::OSC_PORT = "OSC_PORT";
 juce::String const ProjectData::XmlTags::STANDALONE_SPEAKERVIEW_INPUT_PORT = "STANDALONE_SPEAKERVIEW_INPUT_PORT";
 juce::String const ProjectData::XmlTags::STANDALONE_SPEAKERVIEW_OUTPUT_PORT = "STANDALONE_SPEAKERVIEW_OUTPUT_PORT";
 juce::String const ProjectData::XmlTags::STANDALONE_SPEAKERVIEW_OUTPUT_ADDRESS
-    = "STANDALONE_SPEAKERVIEW_OUTPUT_ADDRESS";
+  = "STANDALONE_SPEAKERVIEW_OUTPUT_ADDRESS";
+juce::String const ProjectData::XmlTags::USE_MULTICORE_DSP
+  = "USE_MULTICORE_DSP";
 
 juce::String const AppData::XmlTags::MAIN_TAG = "SPAT_GRIS_APP_DATA";
 juce::String const AppData::XmlTags::LAST_SPEAKER_SETUP = "LAST_SPEAKER_SETUP";
@@ -757,6 +759,7 @@ std::unique_ptr<juce::XmlElement> ProjectData::toXml() const
     result->setAttribute(XmlTags::GAIN_INTERPOLATION, spatGainsInterpolation);
     result->setAttribute(XmlTags::VERSION, SPAT_GRIS_VERSION.toString());
     result->setAttribute(XmlTags::SPAT_MODE, spatModeToString(spatMode));
+    result->setAttribute(XmlTags::USE_MULTICORE_DSP, useMulticoreDSP);
 
     return result;
 }
@@ -817,6 +820,9 @@ tl::optional<ProjectData> ProjectData::fromXml(juce::XmlElement const & xml)
     if (xml.hasAttribute(XmlTags::STANDALONE_SPEAKERVIEW_OUTPUT_ADDRESS)) {
         result.standaloneSpeakerViewOutputAddress
             = xml.getStringAttribute(XmlTags::STANDALONE_SPEAKERVIEW_OUTPUT_ADDRESS);
+    }
+    if (xml.hasAttribute(XmlTags::USE_MULTICORE_DSP)) {
+        result.useMulticoreDSP = xml.getBoolAttribute(XmlTags::USE_MULTICORE_DSP);
     }
 
     for (auto const * sourceElement : sourcesElement->getChildIterator()) {

--- a/Data/sg_LogicStrucs.cpp
+++ b/Data/sg_LogicStrucs.cpp
@@ -846,12 +846,20 @@ tl::optional<ProjectData> ProjectData::fromXml(juce::XmlElement const & xml)
 }
 
 //==============================================================================
+
+  // TODO: we should just serialize as XML and compare the strings. This would make it
+  // less error prone to maintain. I don't think the performance difference matters.
 bool ProjectData::operator==(ProjectData const & other) const noexcept
 {
     return other.ordering == ordering && other.spatGainsInterpolation == spatGainsInterpolation
            && other.oscPort == oscPort && other.masterGain == masterGain
            && other.mbapDistanceAttenuationData == mbapDistanceAttenuationData && other.sources == sources
-           && other.spatMode == spatMode;
+           && other.spatMode == spatMode
+           && other.useMulticoreDSP == useMulticoreDSP
+           && other.standaloneSpeakerViewInputPort == standaloneSpeakerViewInputPort
+           && other.standaloneSpeakerViewOutputPort == standaloneSpeakerViewOutputPort
+           && other.standaloneSpeakerViewOutputAddress == standaloneSpeakerViewOutputAddress
+;
 }
 
 //==============================================================================

--- a/Data/sg_LogicStrucs.cpp
+++ b/Data/sg_LogicStrucs.cpp
@@ -847,8 +847,9 @@ tl::optional<ProjectData> ProjectData::fromXml(juce::XmlElement const & xml)
 
 //==============================================================================
 
-  // TODO: we should just serialize as XML and compare the strings. This would make it
-  // less error prone to maintain. I don't think the performance difference matters.
+// TODO: we should just serialize as XML and compare the strings. This would make it
+// less error prone to maintain. I don't think the performance difference matters : This
+// is called infrequently and is called in methods that also do file IO which is already slow.
 bool ProjectData::operator==(ProjectData const & other) const noexcept
 {
     return other.ordering == ordering && other.spatGainsInterpolation == spatGainsInterpolation

--- a/Data/sg_LogicStrucs.hpp
+++ b/Data/sg_LogicStrucs.hpp
@@ -43,7 +43,7 @@
 #include "../Containers/sg_StrongArray.hpp"
 
 // this is the main switch to enable/disable fork_union
-#define SG_USE_FORK_UNION 0
+#define SG_USE_FORK_UNION 1
 
 // fork_union concurrency method options (used to set SG_FU_METHOD right below)
 // Use an array of atomics for concurrent float access: (vector<vector<AtomicWrapper<float>>>)

--- a/Data/sg_LogicStrucs.hpp
+++ b/Data/sg_LogicStrucs.hpp
@@ -42,21 +42,6 @@
 #include "../Containers/sg_StaticMap.hpp"
 #include "../Containers/sg_StrongArray.hpp"
 
-// this is the main switch to enable/disable fork_union
-#define SG_USE_FORK_UNION 1
-
-// fork_union concurrency method options (used to set SG_FU_METHOD right below)
-// Use an array of atomics for concurrent float access: (vector<vector<AtomicWrapper<float>>>)
-#define SG_FU_USE_ARRAY_OF_ATOMICS 1
-
-// Use a buffer per thread for concurrent float access: (vector<vector<vector<float>>>)
-#define SG_FU_USE_BUFFER_PER_THREAD 2
-
-// Use std::atomic_ref<float> for lock-free atomic access to floats
-#define SG_FU_USE_ATOMIC_CAST 3
-
-// and SG_FU_METHOD is the "algorithm" used by fork_union, which is set to one of the above macros
-#define SG_FU_METHOD SG_FU_USE_ATOMIC_CAST
 
 namespace gris
 {
@@ -83,36 +68,8 @@ enum class AttenuationBypassSate : std::uint8_t { invalid, on, off };
 [[nodiscard]] juce::String attenuationBypassStateToString(AttenuationBypassSate state);
 [[nodiscard]] AttenuationBypassSate stringToAttenuationBypassState(juce::String const & string);
 
-#if SG_USE_FORK_UNION
-    #if SG_FU_METHOD == SG_FU_USE_ARRAY_OF_ATOMICS
-/* Taken from https://stackoverflow.com/questions/13193484/how-to-declare-a-vector-of-atomic-in-c
- **/
-template<typename T>
-struct AtomicWrapper {
-    std::atomic<T> _a;
-
-    AtomicWrapper() : _a() {}
-
-    AtomicWrapper(const std::atomic<T> & a) : _a(a.load()) {}
-
-    AtomicWrapper(const AtomicWrapper & other) : _a(other._a.load()) {}
-
-    /* This isn't atomic so shouldn't be done in concurent contexts! */
-    AtomicWrapper & operator=(const AtomicWrapper & other) { _a.store(other._a.load()); }
-};
-
-// TODO FU: instead of using another set of arrays, could we deal with concurrency inside SpeakerAudioBuffer directly?
-// TODO FU: explore using a boost::multi_array or https://github.com/correaa/boost-multi, with the important point that
-// we need to make sure buffers are separated by std::hardware_destructive_interference_size
-using ForkUnionBuffer = std::vector<std::vector<AtomicWrapper<float>>>;
-
-    #elif SG_FU_METHOD == SG_FU_USE_BUFFER_PER_THREAD
-using ForkUnionBuffer = std::vector<std::vector<std::vector<float>>>;
-
-    #elif SG_FU_METHOD == SG_FU_USE_ATOMIC_CAST
+// warns if float can't be lock free on this specific platform.
 static_assert(std::atomic_ref<float>::is_always_lock_free, "float cannot be converted to a lock-free atomic_ref!");
-    #endif
-#endif
 
 //==============================================================================
 /** For the following data structures, we use the following semantics:
@@ -446,6 +403,11 @@ struct ProjectData {
     dbfs_t masterGain{};
     float spatGainsInterpolation{};
     SpatMode spatMode{};
+    /**
+     * wether or not mbap and vbap processing should be parallelized.
+     */
+    bool useMulticoreDSP{};
+
     //==============================================================================
     [[nodiscard]] std::unique_ptr<juce::XmlElement> toXml() const;
     [[nodiscard]] static tl::optional<ProjectData> fromXml(juce::XmlElement const & xml);
@@ -463,6 +425,7 @@ struct ProjectData {
         static juce::String const STANDALONE_SPEAKERVIEW_INPUT_PORT;
         static juce::String const STANDALONE_SPEAKERVIEW_OUTPUT_PORT;
         static juce::String const STANDALONE_SPEAKERVIEW_OUTPUT_ADDRESS;
+        static juce::String const USE_MULTICORE_DSP;
     };
 };
 


### PR DESCRIPTION
This also fixes a bug where standalone speakerview network settings were not considered to be a modification to the project for save modal purposes.