### PR TITLE
Integrate multicore DSP performance presets

### DIFF
--- a/Data/sg_LogicStrucs.cpp
+++ b/Data/sg_LogicStrucs.cpp
@@ -96,6 +96,9 @@ juce::String const ProjectData::XmlTags::STANDALONE_SPEAKERVIEW_OUTPUT_ADDRESS
   = "STANDALONE_SPEAKERVIEW_OUTPUT_ADDRESS";
 juce::String const ProjectData::XmlTags::USE_MULTICORE_DSP
   = "USE_MULTICORE_DSP";
+juce::String const ProjectData::XmlTags::MULTICORE_DSP_PRESET
+  = "MULTICORE_DSP_PRESET";
+
 
 juce::String const AppData::XmlTags::MAIN_TAG = "SPAT_GRIS_APP_DATA";
 juce::String const AppData::XmlTags::LAST_SPEAKER_SETUP = "LAST_SPEAKER_SETUP";
@@ -760,6 +763,7 @@ std::unique_ptr<juce::XmlElement> ProjectData::toXml() const
     result->setAttribute(XmlTags::VERSION, SPAT_GRIS_VERSION.toString());
     result->setAttribute(XmlTags::SPAT_MODE, spatModeToString(spatMode));
     result->setAttribute(XmlTags::USE_MULTICORE_DSP, useMulticoreDSP);
+    result->setAttribute(XmlTags::MULTICORE_DSP_PRESET, multicoreDSPPreset);
 
     return result;
 }
@@ -824,6 +828,9 @@ tl::optional<ProjectData> ProjectData::fromXml(juce::XmlElement const & xml)
     if (xml.hasAttribute(XmlTags::USE_MULTICORE_DSP)) {
         result.useMulticoreDSP = xml.getBoolAttribute(XmlTags::USE_MULTICORE_DSP);
     }
+    if (xml.hasAttribute(XmlTags::MULTICORE_DSP_PRESET)) {
+        result.multicoreDSPPreset = xml.getIntAttribute(XmlTags::MULTICORE_DSP_PRESET);
+    }
 
     for (auto const * sourceElement : sourcesElement->getChildIterator()) {
         jassert(sourceElement);
@@ -857,6 +864,7 @@ bool ProjectData::operator==(ProjectData const & other) const noexcept
            && other.mbapDistanceAttenuationData == mbapDistanceAttenuationData && other.sources == sources
            && other.spatMode == spatMode
            && other.useMulticoreDSP == useMulticoreDSP
+           && other.multicoreDSPPreset == multicoreDSPPreset
            && other.standaloneSpeakerViewInputPort == standaloneSpeakerViewInputPort
            && other.standaloneSpeakerViewOutputPort == standaloneSpeakerViewOutputPort
            && other.standaloneSpeakerViewOutputAddress == standaloneSpeakerViewOutputAddress

--- a/Data/sg_LogicStrucs.hpp
+++ b/Data/sg_LogicStrucs.hpp
@@ -406,8 +406,12 @@ struct ProjectData {
     /**
      * wether or not mbap and vbap processing should be parallelized.
      */
-    bool useMulticoreDSP{};
+    bool useMulticoreDSP{false};
 
+    /**
+     *
+     */
+    int multicoreDSPPreset{OPTIMIZE_CPU_MULTICORE_PRESET};
     //==============================================================================
     [[nodiscard]] std::unique_ptr<juce::XmlElement> toXml() const;
     [[nodiscard]] static tl::optional<ProjectData> fromXml(juce::XmlElement const & xml);
@@ -426,6 +430,7 @@ struct ProjectData {
         static juce::String const STANDALONE_SPEAKERVIEW_OUTPUT_PORT;
         static juce::String const STANDALONE_SPEAKERVIEW_OUTPUT_ADDRESS;
         static juce::String const USE_MULTICORE_DSP;
+        static juce::String const MULTICORE_DSP_PRESET;
     };
 };
 

--- a/Data/sg_constants.hpp
+++ b/Data/sg_constants.hpp
@@ -70,6 +70,9 @@ struct SpatGrisVersion {
 
 extern const SpatGrisVersion SPAT_GRIS_VERSION;
 
+constexpr int OPTIMIZE_CPU_MULTICORE_PRESET = 0;
+constexpr int OPTIMIZE_LATENCY_MULTICORE_PRESET = 1;
+
 constexpr auto MAX_NUM_SOURCES = 256;
 constexpr auto MAX_NUM_SPEAKERS = 256;
 


### PR DESCRIPTION
This integrates multicore dsp performance presets to the project data struct and is necessary for the upcoming algogris PR that improves multicore DSP performance.  